### PR TITLE
README.md to use correct runtime property key

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can deploy the Starter Kit using either AWS CLI or AWS Console.
     | region  | us-east-1 | AWS region |
     | input_stream_name | kda_flink_starter_kit_kinesis_stream | Input Kinesis Data Stream Name |
     | session_time_out_in_minutes      | 10 | Session timeout in minutes |
-    | stream_initial_position | TRIM_HORIZON | Refer documentation [here](https://ci.apache.org/projects/flink/flink-docs-stable/dev/connectors/kinesis.html#configuring-starting-position) for more details |
+    | stream_init_position | TRIM_HORIZON | Refer documentation [here](https://ci.apache.org/projects/flink/flink-docs-stable/dev/connectors/kinesis.html#configuring-starting-position) for more details |
     | s3_output_path | s3a://<bucket_name>/kda_flink_starter_kit_output | s3 path for Flink Application output |
     | bucket_check_interval_in_seconds | 2 | interval for checking time based rolling policies |
     | rolling_interval_in_seconds      | 2 | the max time a part file can stay open before having to roll |


### PR DESCRIPTION



*Issue #, if available:*

*Description of changes:*

Updated runtime property name in readme to match name in code.

Correct name in context:
https://github.com/aws-samples/amazon-kinesis-data-analytics-flink-starter-kit/blob/7e70b7225b4ab76872818f3979ec48246fb20937/src/main/java/com/amazonaws/kda/flink/starterkit/SessionProcessor.java#L118

If set incorrectly, this breaks the app at runtime with the following error, making the sample app unusable:
>org.apache.flink.client.program.ProgramInvocationException: The main method caused an error: Runtime properties are invalid. Will not proceed to start Kinesis Analytics Application


-

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
