### PR TITLE
updating runtime and jar version

### DIFF
--- a/src/main/resources/flink_starter_kit_def_stream_position_trim_horizon.json
+++ b/src/main/resources/flink_starter_kit_def_stream_position_trim_horizon.json
@@ -1,7 +1,7 @@
 {
 	"ApplicationName": "amazon_kda_flink_starter_kit",
 	"ApplicationDescription": "KDA Session Manager with stream starting position as TRIM_HORIZON",
-	"RuntimeEnvironment": "FLINK-1_8",
+	"RuntimeEnvironment": "FLINK-1_13",
 	"ServiceExecutionRole": "arn:aws:iam::1234567890:role/flink_starter_kit_role",
 	"CloudWatchLoggingOptions": [
 		{
@@ -30,7 +30,7 @@
 			"CodeContent": {
 				"S3ContentLocation": {
 					"BucketARN": "arn:aws:s3:::bucket_name",
-					"FileKey": "kda_flink_starter_kit_jar/amazon-kinesis-data-analytics-flink-starter-kit-0.1.jar"
+					"FileKey": "kda_flink_starter_kit_jar/amazon-kinesis-data-analytics-flink-starter-kit-1.0.jar"
 				}
 			},
 			"CodeContentType": "ZIPFILE"

--- a/src/main/resources/kinesisanalyticsv2 create-application
+++ b/src/main/resources/kinesisanalyticsv2 create-application
@@ -1,0 +1,77 @@
+{
+    "ApplicationDetail": {
+        "ApplicationARN": "arn:aws:kinesisanalytics:us-east-1:259982120143:application/amazon_kda_flink_starter_kit",
+        "ApplicationDescription": "KDA Session Manager with stream starting position as TRIM_HORIZON",
+        "ApplicationName": "amazon_kda_flink_starter_kit",
+        "RuntimeEnvironment": "FLINK-1_8",
+        "ServiceExecutionRole": "arn:aws:iam::259982120143:role/flink_starter_kit_role",
+        "ApplicationStatus": "READY",
+        "ApplicationVersionId": 1,
+        "CreateTimestamp": "2022-04-28T16:09:05+00:00",
+        "LastUpdateTimestamp": "2022-04-28T16:09:05+00:00",
+        "ApplicationConfigurationDescription": {
+            "ApplicationCodeConfigurationDescription": {
+                "CodeContentType": "ZIPFILE",
+                "CodeContentDescription": {
+                    "CodeMD5": "eb66bb06075760bd6b68ddd40cb719b4",
+                    "CodeSize": 46266769,
+                    "S3ApplicationCodeLocationDescription": {
+                        "BucketARN": "arn:aws:s3:::audio-analysis-1239asdfasdjf",
+                        "FileKey": "kda_flink_starter_kit_jar/amazon-kinesis-data-analytics-flink-starter-kit-1.0.jar"
+                    }
+                }
+            },
+            "FlinkApplicationConfigurationDescription": {
+                "CheckpointConfigurationDescription": {
+                    "ConfigurationType": "DEFAULT",
+                    "CheckpointingEnabled": true,
+                    "CheckpointInterval": 60000,
+                    "MinPauseBetweenCheckpoints": 5000
+                },
+                "MonitoringConfigurationDescription": {
+                    "ConfigurationType": "DEFAULT",
+                    "MetricsLevel": "APPLICATION",
+                    "LogLevel": "INFO"
+                },
+                "ParallelismConfigurationDescription": {
+                    "ConfigurationType": "CUSTOM",
+                    "Parallelism": 5,
+                    "ParallelismPerKPU": 1,
+                    "CurrentParallelism": 5,
+                    "AutoScalingEnabled": false
+                }
+            },
+            "EnvironmentPropertyDescriptions": {
+                "PropertyGroupDescriptions": [
+                    {
+                        "PropertyGroupId": "FlinkAppProperties",
+                        "PropertyMap": {
+                            "bucket_check_interval_in_seconds": "2",
+                            "inactivity_interval_in_seconds": "2",
+                            "input_stream_name": "kda_flink_starter_kit_kinesis_stream",
+                            "region": "us-east-1",
+                            "rolling_interval_in_seconds": "2",
+                            "s3_output_path": "s3a://audio-analysis-1239asdfasdjf/kda_flink_starter_kit_output",
+                            "session_time_out_in_minutes": "10",
+                            "stream_init_position": "TRIM_HORIZON"
+                        }
+                    }
+                ]
+            },
+            "ApplicationSnapshotConfigurationDescription": {
+                "SnapshotsEnabled": true
+            }
+        },
+        "CloudWatchLoggingOptionDescriptions": [
+            {
+                "CloudWatchLoggingOptionId": "1.1",
+                "LogStreamARN": "arn:aws:logs:us-east-1:259982120143:log-group:/aws/kinesis-analytics/kda_flink_starter_kit:log-stream:kda_flink_starter_kit"
+            }
+        ],
+        "ApplicationMaintenanceConfigurationDescription": {
+            "ApplicationMaintenanceWindowStartTime": "03:00",
+            "ApplicationMaintenanceWindowEndTime": "11:00"
+        },
+        "ConditionalToken": "861ec7a4c0b90eeef749f2cee38cf2db"
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updating Java Runtime and the Jar name in the `flink_starter_kit_def_stream_position_trim_horizon.json` file

Issue was related to https://stackoverflow.com/questions/58125830/has-been-compiled-by-a-more-recent-version-of-the-java-runtime-class-file-versi

Logs:

```
{
    "applicationARN": "arn:aws:kinesisanalytics:us-east-1:<>:application/amazon_kda_flink_starter_kit",
    "applicationVersionId": 1,
    "message": "org.apache.flink.client.program.ProgramInvocationException: The program's entry point class 'com.amazonaws.kda.flink.starterkit.SessionProcessor' could not be loaded due to a linkage failure. StackTrace: java.util.concurrent.CompletionException: org.apache.flink.client.program.ProgramInvocationException: The program's entry point class 'com.amazonaws.kda.flink.starterkit.SessionProcessor' could not be loaded due to a linkage failure.\n\tat org.apache.flink.runtime.webmonitor.handlers.JarRunOverrideHandler.lambda$getJobGraphAsync$10(JarRunOverrideHandler.java:475)\n\tat java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1604)\n\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n\tat java.lang.Thread.run(Thread.java:748)\nCaused by: org.apache.flink.client.program.ProgramInvocationException: The program's entry point class 'com.amazonaws.kda.flink.starterkit.SessionProcessor' could not be loaded due to a linkage failure.\n\tat org.apache.flink.client.program.PackagedProgram.loadMainClass(PackagedProgram.java:659)\n\tat org.apache.flink.client.program.PackagedProgram.<init>(PackagedProgram.java:228)\n\tat org.apache.flink.runtime.webmonitor.handlers.JarRunOverrideHandler.lambda$getJobGraphAsync$10(JarRunOverrideHandler.java:471)\n\t... 4 more\nCaused by: java.lang.UnsupportedClassVersionError: com/amazonaws/kda/flink/starterkit/SessionProcessor has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0\n\tat java.lang.ClassLoader.defineClass1(Native Method)\n\tat java.lang.ClassLoader.defineClass(ClassLoader.java:756)\n\tat java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)\n\tat java.net.URLClassLoader.defineClass(URLClassLoader.java:473)\n\tat java.net.URLClassLoader.access$100(URLClassLoader.java:74)\n\tat java.net.URLClassLoader$1.run(URLClassLoader.java:369)\n\tat java.net.URLClassLoader$1.run(URLClassLoader.java:363)\n\tat java.security.AccessController.doPrivileged(Native Method)\n\tat java.net.URLClassLoader.findClass(URLClassLoader.java:362)\n\tat org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders$ChildFirstClassLoader.loadClass(FlinkUserCodeClassLoaders.java:130)\n\tat java.lang.ClassLoader.loadClass(ClassLoader.java:351)\n\tat java.lang.Class.forName0(Native Method)\n\tat java.lang.Class.forName(Class.java:348)\n\tat org.apache.flink.client.program.PackagedProgram.loadMainClass(PackagedProgram.java:648)\n\t... 6 more\n",
    "messageType": "ERROR",
    "messageSchemaVersion": "1",
    "errorCode": "CodeError.InvalidApplicationCode"
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
